### PR TITLE
ci/v8: update Go version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,10 +2,12 @@ name: v7
 on:
   push:
     paths-ignore:
-    - 'v[0-9]+/**'
+      - 'v[0-9]+/**'
+      - '.github/workflows/testingv8.yml'
   pull_request:
     paths-ignore:
-    - 'v[0-9]+/**'
+      - 'v[0-9]+/**'
+      - '.github/workflows/testingv8.yml'
 
 jobs:
   build:

--- a/.github/workflows/testingv8.yml
+++ b/.github/workflows/testingv8.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - 'v8/**'
+      - '.github/workflows/testingv8.yml'
   pull_request:
     paths:
       - 'v8/**'
+      - '.github/workflows/testingv8.yml'
 
 jobs:
   build:
@@ -14,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18.x', '1.19.x', '1.20.x' ]
+        go: [ 'oldstable', 'stable' ]
     env:
       TEST_KDC_ADDR: 127.0.0.1
       TEST_HTTP_URL: http://cname.test.gokrb5


### PR DESCRIPTION
Updates the Go version in the v8 CI config to automatically use the two supported Go versions.